### PR TITLE
docs: dynamodb cost-analysis + s3 --all-buckets

### DIFF
--- a/docs/commands/dynamodb.md
+++ b/docs/commands/dynamodb.md
@@ -1,0 +1,53 @@
+# DynamoDB Commands
+
+The DynamoDB command group analyzes DynamoDB tables for provisioned capacity and estimated monthly cost, helping surface over-provisioned or idle tables.
+
+## Commands
+
+### `cost-analysis`
+
+Scan DynamoDB tables and report capacity, size, and estimated monthly cost, with a summary of the most expensive tables and totals grouped by project prefix.
+
+```bash
+aws-cloud-utilities dynamodb cost-analysis [OPTIONS]
+```
+
+#### Options
+
+- `--region REGION` - Single region to scan (default: all regions)
+- `--all-regions` - Scan all regions (this is the default behavior)
+- `--top N` - Number of top-expensive tables to show (default: 10)
+- `--output-file FILE` - Save results to file (`.json`, `.yaml`, `.csv`)
+- `--profile PROFILE` - AWS profile to use
+- `--output FORMAT` - Output format (table, json, yaml, csv)
+
+#### How cost is estimated
+
+For **provisioned-throughput** tables the estimated monthly cost is:
+
+```
+(ReadCapacityUnits + WriteCapacityUnits) * $0.0072 * 24 * 30
+```
+
+This uses us-west-2 provisioned pricing. **On-demand** (`PAY_PER_REQUEST`) tables are listed but shown as `On-Demand`; their cost is usage-based and cannot be derived from table metadata, so they are excluded from the provisioned-cost totals.
+
+#### What it reports
+
+- Per-table: region, billing mode, RCU/WCU, item count, size, and estimated monthly cost (sorted by cost)
+- Total provisioned RCU/WCU and estimated monthly cost
+- Top-N most expensive tables
+- "Empty but expensive" tables (zero items but a meaningful provisioned cost)
+- Cost totals grouped by project prefix (the part of the table name before the first `-`)
+
+#### Examples
+
+```bash
+# Analyze every region
+aws-cloud-utilities dynamodb cost-analysis
+
+# Analyze a single region
+aws-cloud-utilities dynamodb cost-analysis --region us-east-1
+
+# Show the top 5 and save a JSON report
+aws-cloud-utilities dynamodb cost-analysis --top 5 --output-file dynamodb-cost.json
+```

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -43,6 +43,7 @@ All 18 command groups with their complete subcommand list. Click any service nam
 | [**bedrock**](bedrock.md) | Amazon Bedrock AI/ML operations | `list-models`, `model-details`, `list-custom-models`, `list-model-jobs`, `regions` (5 commands) |
 | [**cloudformation**](cloudformation.md) | CloudFormation stack management | `backup`, `list-stacks`, `stack-details` (3 commands) |
 | [**cloudfront**](cloudfront.md) | CloudFront distribution management | `update-logging`, `list-distributions`, `distribution-details`, `invalidate` (4 commands) |
+| [**dynamodb**](dynamodb.md) | DynamoDB cost and capacity analysis | `cost-analysis` (1 command) |
 | [**ecr**](ecr.md) | Elastic Container Registry operations | `copy-image`, `list-repositories`, `list-images`, `create-repository`, `delete-repository`, `get-login` (6 commands) |
 | [**iam**](iam.md) | IAM management and auditing | `audit`, `list-roles`, `list-policies`, `role-details`, `policy-details` (5 commands) |
 | [**logs**](logs.md) | CloudWatch logs management | `list-groups`, `download`, `set-retention`, `delete-group`, `combine`, `aggregate` (6 commands) |

--- a/docs/commands/s3.md
+++ b/docs/commands/s3.md
@@ -125,36 +125,48 @@ aws-cloud-utilities s3 nuke-bucket my-versioned-bucket --delete-versions --force
 
 ### `bucket-details`
 
-Get comprehensive details about an S3 bucket.
+Get comprehensive details about a single S3 bucket, or every bucket in the
+account with `--all-buckets`.
 
 ```bash
 aws-cloud-utilities s3 bucket-details BUCKET_NAME
+aws-cloud-utilities s3 bucket-details --all-buckets
 ```
 
+Provide exactly one of `BUCKET_NAME` or `--all-buckets`. In all-buckets mode
+the per-bucket detail fetches run in parallel (using the configured worker
+count) and each bucket's region is auto-detected.
+
 **Arguments:**
-- `BUCKET_NAME` - Name of the bucket to analyze
+- `BUCKET_NAME` - Name of the bucket to analyze (omit when using `--all-buckets`)
 
 **Options:**
-- `--include-objects` - Include object listing in details
-- `--max-objects NUM` - Maximum number of objects to list (default: 1000)
-- `--output-file FILE` - Save results to file
+- `--all-buckets` - Get details for every bucket in the account
+- `--region REGION` - Region where the bucket is located (default: auto-detect)
+- `--include-policies` - Include bucket policies and ACLs
+- `--include-lifecycle` - Include lifecycle configuration
+- `--include-cors` - Include CORS configuration
+- `--include-website` - Include website configuration
+- `--include-logging` - Include logging configuration
+- `--include-all` - Include all available bucket details
+- `--output-file FILE` - Save results to file (`.json`, `.yaml`)
 
 **Features:**
 - Bucket configuration and policies
 - Versioning and lifecycle settings
 - Encryption and access control
-- Object statistics and samples
+- Size and object count
 
 **Examples:**
 ```bash
-# Get bucket details
+# Get details for one bucket
 aws-cloud-utilities s3 bucket-details my-bucket
 
-# Include object listing
-aws-cloud-utilities s3 bucket-details my-bucket --include-objects
+# Details for every bucket in the account
+aws-cloud-utilities s3 bucket-details --all-buckets
 
-# Save to file
-aws-cloud-utilities s3 bucket-details my-bucket --output-file bucket-analysis.json
+# All buckets, full details, saved to file
+aws-cloud-utilities s3 bucket-details --all-buckets --include-all --output-file buckets.json
 ```
 
 ### `delete-versions`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,6 +111,7 @@ nav:
     - CloudFront CDN: commands/cloudfront.md
     - Cost Optimization: commands/costops.md
     - Container Registry (ECR): commands/ecr.md
+    - DynamoDB: commands/dynamodb.md
     - IAM Management: commands/iam.md
     - Inventory & Discovery: commands/inventory.md
     - Log Management: commands/logs.md


### PR DESCRIPTION
## Summary
Documentation for the two features shipped in this sprint (#197, #185):

- New `docs/commands/dynamodb.md` covering `dynamodb cost-analysis` (options, cost formula, on-demand handling, what it reports).
- Updated `docs/commands/s3.md` `bucket-details` section to document the new `--all-buckets` mode.
- Added **DynamoDB** to the mkdocs nav and the commands index table.

Validated with `mkdocs build --strict` (clean).

Relates to #197, #185.

## Test Plan
- [x] `mkdocs build --strict` succeeds with no warnings