### PR TITLE
feat(billing): add cur-setup for end-to-end CUR provisioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to AWS Cloud Utilities will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `billing cur-setup` command: provisions an end-to-end Cost and Usage Report
+  data source in one step — creates and configures the delivery S3 bucket
+  (public-access block, AES256 encryption, lifecycle policy, and the
+  billing-service bucket policy) and registers a Parquet CUR report definition
+  with resource IDs. Mirrors the reference Terraform module.
+- `--dry-run` support for `cur-setup` to preview the plan without creating any
+  resources, plus idempotent detection of existing buckets and report
+  definitions.
+
 ## [2.1.2] - 2025-08-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # AWS Cloud Utilities v2
 
+[![CI](https://github.com/jon-the-dev/aws-cloud-tools/actions/workflows/ci.yml/badge.svg)](https://github.com/jon-the-dev/aws-cloud-tools/actions/workflows/ci.yml) [![Security Checks](https://github.com/jon-the-dev/aws-cloud-tools/actions/workflows/security-checks.yml/badge.svg)](https://github.com/jon-the-dev/aws-cloud-tools/actions/workflows/security-checks.yml) ![PyPI](https://img.shields.io/pypi/v/aws-cloud-utilities) ![Python 3.12](https://img.shields.io/badge/python-3.12-3776AB?logo=python&logoColor=white) ![pipenv](https://img.shields.io/badge/pipenv-3776AB?logo=python&logoColor=white) ![License](https://img.shields.io/github/license/jon-the-dev/aws-cloud-tools) ![Issues](https://img.shields.io/github/issues/jon-the-dev/aws-cloud-tools) ![Last Commit](https://img.shields.io/github/last-commit/jon-the-dev/aws-cloud-tools)
+
 A unified command-line toolkit for AWS operations with enhanced functionality. This package consolidates various AWS management scripts into a single, powerful CLI tool.
 
 ## Prerequisites
@@ -41,11 +43,14 @@ pip install -e .
 # Get account information
 aws-cloud-utilities account info
 
-# List all resources in your account
-aws-cloud-utilities inventory resources
+# Inventory all resources in your account
+aws-cloud-utilities inventory scan
 
-# Find cheapest GPU spot instances
-aws-cloud-utilities costops gpu-spots --instance-type p3.2xlarge
+# Provision a Cost and Usage Report data source end-to-end
+aws-cloud-utilities billing cur-setup --bucket my-cur-bucket
+
+# Find the cheapest spot instances
+aws-cloud-utilities costops spot-analysis
 
 # Troubleshoot MySQL RDS connection issues
 aws-cloud-utilities rds troubleshoot-mysql my-mysql-db
@@ -53,8 +58,8 @@ aws-cloud-utilities rds troubleshoot-mysql my-mysql-db
 # Aggregate CloudWatch logs
 aws-cloud-utilities logs aggregate --log-group /aws/lambda/my-function
 
-# Security audit
-aws-cloud-utilities security blue-team-audit
+# Collect security metrics (WAF, GuardDuty, Security Hub)
+aws-cloud-utilities security metrics
 
 # Analyze S3 encryption (generates HTML report)
 aws-cloud-utilities s3 analyze-encryption --workers 20
@@ -68,19 +73,6 @@ The CLI follows a hierarchical structure similar to the AWS CLI:
 aws-cloud-utilities [GLOBAL-OPTIONS] <service> <operation> [OPTIONS]
 ```
 
-### Available Services
-
-- **account**: Account information and management
-- **costops**: Cost optimization and pricing tools
-- **inventory**: Resource discovery and inventory
-- **logs**: CloudWatch logs management
-- **rds**: RDS management and troubleshooting
-- **security**: Security auditing and tools
-- **s3**: S3 bucket operations
-- **iam**: IAM management and auditing
-- **networking**: Network utilities
-- **support**: AWS support tools
-
 ### Global Options
 
 - `--profile`: AWS profile to use
@@ -88,6 +80,176 @@ aws-cloud-utilities [GLOBAL-OPTIONS] <service> <operation> [OPTIONS]
 - `--output`: Output format (json, yaml, table)
 - `--verbose`: Enable verbose logging
 - `--debug`: Enable debug mode
+
+## Command Index
+
+Every command group and its operations. Invoke as
+`aws-cloud-utilities <group> <command> [OPTIONS]`.
+
+| Group | Purpose |
+|-------|---------|
+| [`account`](#account) | Account information and management |
+| [`awsconfig`](#awsconfig) | AWS Config compliance monitoring |
+| [`bedrock`](#bedrock) | Amazon Bedrock model management |
+| [`billing`](#billing) | Billing and Cost & Usage Report (CUR) management |
+| [`cloudformation`](#cloudformation) | CloudFormation management and backup |
+| [`cloudfront`](#cloudfront) | CloudFront distribution management |
+| [`costops`](#costops) | Cost optimization and pricing analysis |
+| [`dynamodb`](#dynamodb) | DynamoDB cost and capacity analysis |
+| [`ecr`](#ecr) | Elastic Container Registry management |
+| [`iam`](#iam) | IAM management and auditing |
+| [`inventory`](#inventory) | Resource discovery and inventory |
+| [`logs`](#logs) | CloudWatch Logs management and processing |
+| [`networking`](#networking) | Networking and IP-range utilities |
+| [`rds`](#rds) | RDS management and troubleshooting |
+| [`s3`](#s3) | S3 bucket and object management |
+| [`security`](#security) | Security monitoring and certificates |
+| [`stepfunctions`](#stepfunctions) | Step Functions management and monitoring |
+| [`trusted-advisor`](#trusted-advisor) | Trusted Advisor and AWS support tools |
+| [`waf`](#waf) | WAF management and troubleshooting |
+
+### account
+
+- `info` — Get AWS account information
+- `contact-info` — Get AWS account contact information
+- `detect-control-tower` — Detect AWS Control Tower or Landing Zone deployments
+- `regions` — List all available AWS regions
+- `service-regions` — List available regions for a specific AWS service
+- `limits` — Get AWS service limits and usage
+- `validate` — Validate AWS credentials and permissions
+
+### awsconfig
+
+- `download` — Download and process AWS Config files from S3 into CSV or JSON
+- `show-rules` — Show AWS Config rules with compliance metrics
+- `list-rules` — List AWS Config rules with basic information
+- `compliance-status` — Compliance status summary across rules and resources
+- `compliance-checker` — Comprehensive compliance checker for various resource types
+
+### bedrock
+
+- `list-models` — List Amazon Bedrock foundation models across regions
+- `model-details` — Get detailed information about a specific Bedrock model
+- `list-custom-models` — List custom Bedrock models
+- `list-model-jobs` — List Bedrock model customization jobs
+- `regions` — List regions where Amazon Bedrock is available
+
+### billing
+
+- `cur-setup` — Provision an end-to-end CUR data source: bucket, policy, and Parquet report **(new)**
+- `cur-list` — List all existing Cost and Usage Reports
+- `cur-details` — Show detailed configuration for a specific CUR report
+- `cur-create` — Create a new Cost and Usage Report (CUR 2.0)
+- `cur-delete` — Delete a Cost and Usage Report
+- `cur-validate-bucket` — Validate S3 bucket permissions for CUR delivery
+
+### cloudformation
+
+- `backup` — Backup CloudFormation stacks and templates across regions
+- `list-stacks` — List CloudFormation stacks with details
+- `stack-details` — Get detailed information about a specific stack
+
+### cloudfront
+
+- `update-logging` — Enable logging on distributions and optionally set up alarms
+- `list-distributions` — List CloudFront distributions with configuration details
+- `distribution-details` — Get detailed information about a specific distribution
+- `invalidate` — Invalidate distribution cache by domain name or distribution ID
+
+### costops
+
+- `pricing` — Get AWS pricing information for services
+- `cost-analysis` — Analyze AWS costs using Cost Explorer
+- `ebs-optimization` — Analyze EBS volumes for cost optimization opportunities
+- `usage-metrics` — Get detailed usage metrics for a specific AWS service
+- `spot-pricing` — Collect and analyze EC2 spot pricing across regions
+- `spot-analysis` — Analyze collected spot pricing to find cheapest options
+
+### dynamodb
+
+- `cost-analysis` — Analyze DynamoDB tables for capacity usage and estimated monthly cost
+
+### ecr
+
+- `copy-image` — Copy a Docker image from any registry to AWS ECR
+- `list-repositories` — List ECR repositories with details
+- `list-images` — List images in an ECR repository
+- `create-repository` — Create a new ECR repository
+- `delete-repository` — Delete an ECR repository
+- `get-login` — Get Docker login command for ECR or execute login directly
+
+### iam
+
+- `audit` — Audit IAM roles and policies, saving them locally
+- `list-roles` — List IAM roles with details
+- `list-policies` — List IAM policies
+- `role-details` — Get detailed information about a specific IAM role
+- `policy-details` — Get detailed information about a specific IAM policy
+
+### inventory
+
+- `scan` — Comprehensive AWS resource inventory scan across services and regions
+- `workspaces` — Generate a WorkSpaces inventory report with optional metrics
+- `services` — List all supported services for inventory scanning
+- `download-all` — Download comprehensive inventory of all AWS resources
+
+### logs
+
+- `list-groups` — List CloudWatch log groups with details
+- `download` — Download logs for a specific log group or all groups
+- `set-retention` — Set retention policy for a log group
+- `delete-group` — Delete a CloudWatch log group
+- `combine` — Combine multiple log files into a single sorted file
+- `aggregate` — Aggregate log files into larger files for efficient processing
+
+### networking
+
+- `ip-ranges` — Download and analyze AWS IP ranges
+- `ip-summary` — Show summary statistics of AWS IP ranges
+
+### rds
+
+- `troubleshoot-mysql` — Troubleshoot MySQL RDS connection issues
+- `list-instances` — List RDS instances in the current region
+
+### s3
+
+- `list-buckets` — List S3 buckets with region and optional size information
+- `create-bucket` — Create a new S3 bucket with optional configuration
+- `download` — Download objects from a bucket with parallel processing
+- `nuke-bucket` — Completely delete a bucket and all its contents (including versions)
+- `bucket-details` — Get comprehensive details about a bucket
+- `delete-versions` — Delete object versions from a bucket
+- `restore-objects` — Restore objects from Glacier or other archive classes
+- `analyze-encryption` — Analyze bucket encryption configurations (parallel)
+
+### security
+
+- `metrics` — Collect security metrics from WAF, GuardDuty, and Security Hub
+- `create-certificate` — Create an ACM certificate with Route53 DNS validation
+- `list-certificates` — List ACM certificates with details
+
+### stepfunctions
+
+- `list` — List all Step Functions state machines
+- `describe` — Get detailed information about a state machine
+- `execute` — Start an execution of a state machine
+- `list-executions` — List executions of a state machine
+- `logs` — Show CloudWatch logs for an execution
+
+### trusted-advisor
+
+- `check-level` — Check AWS support level using different methods
+- `severity-levels` — List available support severity levels
+- `cases` — List AWS support cases
+- `services` — List AWS services available for support cases
+- `cost-savings` — Analyze Trusted Advisor cost optimization opportunities
+
+### waf
+
+- `list` — List all Web ACLs in the account
+- `stats` — Get comprehensive WAF statistics for troubleshooting
+- `troubleshoot` — Generate a comprehensive WAF troubleshooting report
 
 ## Configuration
 

--- a/aws_cloud_utilities/commands/billing.py
+++ b/aws_cloud_utilities/commands/billing.py
@@ -217,14 +217,18 @@ class CURManager:
                 raise AWSError(f"CUR report '{report_name}' already exists")
             raise AWSError(f"Failed to create CUR report: {e}")
 
-    def _create_bucket_policy(self, bucket_name: str, prefix: str) -> None:
+    def _create_bucket_policy(
+        self, bucket_name: str, prefix: str, s3_client: Optional[Any] = None
+    ) -> None:
         """
         Create S3 bucket policy for CUR delivery
 
         Args:
             bucket_name: S3 bucket name
             prefix: S3 prefix for CUR files
+            s3_client: Optional region-scoped S3 client (defaults to session client)
         """
+        client = s3_client or self.s3_client
         self.logger.info(f"Creating bucket policy for CUR delivery: {bucket_name}")
 
         bucket_policy = {
@@ -258,13 +262,287 @@ class CURManager:
         }
 
         try:
-            self.s3_client.put_bucket_policy(
+            client.put_bucket_policy(
                 Bucket=bucket_name, Policy=json.dumps(bucket_policy)
             )
             self.logger.info(f"Successfully created bucket policy for {bucket_name}")
 
         except Exception as e:
             raise AWSError(f"Failed to create bucket policy: {e}")
+
+    def bucket_exists(self, bucket_name: str, s3_client: Optional[Any] = None) -> bool:
+        """Return True if the S3 bucket already exists and is accessible.
+
+        Args:
+            bucket_name: S3 bucket name
+            s3_client: Optional region-scoped S3 client (defaults to session client)
+
+        Returns:
+            True if the bucket exists, False if it does not.
+        """
+        client = s3_client or self.s3_client
+        try:
+            client.head_bucket(Bucket=bucket_name)
+            return True
+        except Exception as e:
+            if any(code in str(e) for code in ("404", "NoSuchBucket", "Not Found")):
+                return False
+            # 403 means the bucket exists but is owned by someone else.
+            if "403" in str(e) or "Forbidden" in str(e):
+                raise AWSError(
+                    f"Bucket '{bucket_name}' exists but is not owned by this account"
+                )
+            raise AWSError(f"Failed to check bucket '{bucket_name}': {e}")
+
+    def report_exists(self, report_name: str) -> bool:
+        """Return True if a CUR report definition with this name already exists.
+
+        Args:
+            report_name: Name of the CUR report
+
+        Returns:
+            True if the report definition exists, False otherwise.
+        """
+        return self.get_cur_details(report_name) is not None
+
+    def create_cur_bucket(self, bucket_name: str, region: str, s3_client: Any) -> None:
+        """Create the CUR S3 bucket in the given region.
+
+        us-east-1 must not receive a ``CreateBucketConfiguration`` block; every
+        other region requires a matching ``LocationConstraint``.
+
+        Args:
+            bucket_name: S3 bucket name to create
+            region: Region to create the bucket in
+            s3_client: Region-scoped S3 client
+        """
+        self.logger.info(f"Creating CUR bucket '{bucket_name}' in {region}")
+        try:
+            if region == "us-east-1":
+                s3_client.create_bucket(Bucket=bucket_name)
+            else:
+                s3_client.create_bucket(
+                    Bucket=bucket_name,
+                    CreateBucketConfiguration={"LocationConstraint": region},
+                )
+        except Exception as e:
+            if "BucketAlreadyOwnedByYou" in str(e):
+                self.logger.info(
+                    f"Bucket '{bucket_name}' already owned by this account"
+                )
+                return
+            raise AWSError(f"Failed to create bucket '{bucket_name}': {e}")
+
+    def apply_bucket_security(
+        self, bucket_name: str, enable_versioning: bool, s3_client: Any
+    ) -> None:
+        """Apply public-access block, default encryption, and optional versioning.
+
+        Args:
+            bucket_name: S3 bucket name
+            enable_versioning: Enable bucket versioning when True
+            s3_client: Region-scoped S3 client
+        """
+        s3_client.put_public_access_block(
+            Bucket=bucket_name,
+            PublicAccessBlockConfiguration={
+                "BlockPublicAcls": True,
+                "IgnorePublicAcls": True,
+                "BlockPublicPolicy": True,
+                "RestrictPublicBuckets": True,
+            },
+        )
+        s3_client.put_bucket_encryption(
+            Bucket=bucket_name,
+            ServerSideEncryptionConfiguration={
+                "Rules": [
+                    {"ApplyServerSideEncryptionByDefault": {"SSEAlgorithm": "AES256"}}
+                ]
+            },
+        )
+        if enable_versioning:
+            s3_client.put_bucket_versioning(
+                Bucket=bucket_name,
+                VersioningConfiguration={"Status": "Enabled"},
+            )
+
+    def apply_lifecycle_policy(
+        self, bucket_name: str, prefix: str, retention_days: int, s3_client: Any
+    ) -> None:
+        """Apply the CUR lifecycle policy (expiry + multipart cleanup).
+
+        Mirrors the reference Terraform: expire objects under the CUR prefix
+        after ``retention_days``, expire noncurrent versions after 30 days, and
+        abort incomplete multipart uploads after 7 days.
+
+        Args:
+            bucket_name: S3 bucket name
+            prefix: CUR S3 prefix
+            retention_days: Days before CUR objects are expired
+            s3_client: Region-scoped S3 client
+        """
+        s3_client.put_bucket_lifecycle_configuration(
+            Bucket=bucket_name,
+            LifecycleConfiguration={
+                "Rules": [
+                    {
+                        "ID": "delete-old-cur-data",
+                        "Status": "Enabled",
+                        "Filter": {"Prefix": f"{prefix}/"},
+                        "Expiration": {"Days": retention_days},
+                        "NoncurrentVersionExpiration": {"NoncurrentDays": 30},
+                    },
+                    {
+                        "ID": "abort-incomplete-multipart-uploads",
+                        "Status": "Enabled",
+                        "Filter": {"Prefix": ""},
+                        "AbortIncompleteMultipartUpload": {"DaysAfterInitiation": 7},
+                    },
+                ]
+            },
+        )
+
+    def create_report_definition(
+        self,
+        report_name: str,
+        s3_bucket: str,
+        s3_prefix: str,
+        time_unit: str,
+        s3_region: str,
+    ) -> None:
+        """Create the CUR report definition (Parquet, resource IDs, overwrite).
+
+        Mirrors the reference Terraform ``aws_cur_report_definition``.
+
+        Args:
+            report_name: Name for the CUR report
+            s3_bucket: Delivery bucket
+            s3_prefix: Delivery prefix
+            time_unit: HOURLY or DAILY
+            s3_region: Region of the delivery bucket
+        """
+        report_definition = {
+            "ReportName": report_name,
+            "TimeUnit": time_unit,
+            "Format": "Parquet",
+            "Compression": "Parquet",
+            "AdditionalSchemaElements": ["RESOURCES"],
+            "S3Bucket": s3_bucket,
+            "S3Prefix": s3_prefix,
+            "S3Region": s3_region,
+            "RefreshClosedReports": True,
+            "ReportVersioning": "OVERWRITE_REPORT",
+        }
+        try:
+            self.cur_client.put_report_definition(ReportDefinition=report_definition)
+            self.logger.info(f"Successfully created CUR report: {report_name}")
+        except Exception as e:
+            if "DuplicateReportNameException" in str(e):
+                raise AWSError(f"CUR report '{report_name}' already exists")
+            raise AWSError(f"Failed to create CUR report: {e}")
+
+    def _build_setup_plan(
+        self,
+        bucket: str,
+        prefix: str,
+        retention_days: int,
+        enable_versioning: bool,
+        report_name: str,
+        time_unit: str,
+        bucket_present: bool,
+        report_present: bool,
+    ) -> List[Dict[str, str]]:
+        """Build the ordered list of steps describing the target CUR state."""
+        steps = [
+            {
+                "resource": f"S3 bucket s3://{bucket}",
+                "action": "already exists" if bucket_present else "create",
+            },
+            {"resource": "Public access block (all blocked)", "action": "apply"},
+            {"resource": "Default encryption (AES256)", "action": "apply"},
+        ]
+        if enable_versioning:
+            steps.append({"resource": "Bucket versioning", "action": "enable"})
+        steps.append(
+            {
+                "resource": f"Lifecycle (expire {prefix}/ after {retention_days}d)",
+                "action": "apply",
+            }
+        )
+        steps.append(
+            {
+                "resource": "Bucket policy (billingreports.amazonaws.com)",
+                "action": "apply",
+            }
+        )
+        steps.append(
+            {
+                "resource": f"CUR report '{report_name}' ({time_unit}, Parquet)",
+                "action": "already exists — skipped" if report_present else "create",
+            }
+        )
+        return steps
+
+    def setup_cur(
+        self,
+        report_name: str,
+        bucket: str,
+        prefix: str,
+        time_unit: str,
+        retention_days: int,
+        region: Optional[str] = None,
+        enable_versioning: bool = False,
+        dry_run: bool = False,
+    ) -> Dict[str, Any]:
+        """Provision an end-to-end CUR data source (bucket + policy + report).
+
+        Idempotent-friendly: an existing bucket keeps its data (config is still
+        re-applied) and an existing report definition is left untouched.
+
+        Args:
+            report_name: Name for the CUR report
+            bucket: S3 bucket for CUR delivery
+            prefix: S3 prefix for CUR files
+            time_unit: HOURLY or DAILY granularity
+            retention_days: Days before CUR objects are expired
+            region: Bucket region (defaults to the session region, then us-east-1)
+            enable_versioning: Enable bucket versioning when True
+            dry_run: Print the plan without creating anything when True
+
+        Returns:
+            Summary dict with the resolved region, dry_run flag, and step plan.
+        """
+        region = region or self.aws_auth.region_name or "us-east-1"
+        s3_client = self.aws_auth.get_client("s3", region_name=region)
+
+        bucket_present = self.bucket_exists(bucket, s3_client)
+        report_present = self.report_exists(report_name)
+
+        steps = self._build_setup_plan(
+            bucket,
+            prefix,
+            retention_days,
+            enable_versioning,
+            report_name,
+            time_unit,
+            bucket_present,
+            report_present,
+        )
+        summary = {"region": region, "dry_run": dry_run, "steps": steps}
+        if dry_run:
+            return summary
+
+        if not bucket_present:
+            self.create_cur_bucket(bucket, region, s3_client)
+        self.apply_bucket_security(bucket, enable_versioning, s3_client)
+        self.apply_lifecycle_policy(bucket, prefix, retention_days, s3_client)
+        self._create_bucket_policy(bucket, prefix, s3_client)
+
+        if not report_present:
+            self.create_report_definition(
+                report_name, bucket, prefix, time_unit, region
+            )
+        return summary
 
     def delete_cur_report(self, report_name: str) -> bool:
         """
@@ -477,6 +755,92 @@ def cur_create(
 
     except Exception as e:
         console.print(f"[red]Error creating CUR report:[/red] {e}")
+        raise click.Abort()
+
+
+@billing_group.command(name="cur-setup")
+@click.option("--bucket", required=True, help="S3 bucket name for CUR delivery")
+@click.option(
+    "--report-name",
+    default="hourly-cur",
+    show_default=True,
+    help="Name for the CUR report",
+)
+@click.option(
+    "--prefix", default="cur", show_default=True, help="S3 prefix for CUR files"
+)
+@click.option(
+    "--time-unit",
+    type=click.Choice(["HOURLY", "DAILY"]),
+    default="HOURLY",
+    show_default=True,
+    help="CUR time granularity",
+)
+@click.option(
+    "--retention-days",
+    type=int,
+    default=365,
+    show_default=True,
+    help="Days before CUR objects are expired by the bucket lifecycle policy",
+)
+@click.option(
+    "--region",
+    help="Region for the S3 bucket (defaults to the session region)",
+)
+@click.option("--enable-versioning", is_flag=True, help="Enable S3 bucket versioning")
+@click.option(
+    "--dry-run", is_flag=True, help="Print the plan without creating anything"
+)
+@click.pass_context
+def cur_setup(
+    ctx: click.Context,
+    bucket: str,
+    report_name: str,
+    prefix: str,
+    time_unit: str,
+    retention_days: int,
+    region: Optional[str],
+    enable_versioning: bool,
+    dry_run: bool,
+) -> None:
+    """Provision an end-to-end CUR data source (bucket, policy, and report).
+
+    Creates the delivery bucket with a public-access block, AES256 encryption, a
+    lifecycle policy, and the billing-service bucket policy, then registers a
+    Parquet CUR report with resource IDs. Mirrors the reference Terraform.
+    """
+    aws_auth: AWSAuth = ctx.obj["aws_auth"]
+
+    try:
+        cur_manager = CURManager(aws_auth)
+        summary = cur_manager.setup_cur(
+            report_name=report_name,
+            bucket=bucket,
+            prefix=prefix,
+            time_unit=time_unit,
+            retention_days=retention_days,
+            region=region,
+            enable_versioning=enable_versioning,
+            dry_run=dry_run,
+        )
+
+        header = "Planned CUR setup (dry run)" if dry_run else "CUR setup"
+        console.print(
+            f"\n[blue]{header}[/blue] [dim](region: {summary['region']})[/dim]"
+        )
+        for step in summary["steps"]:
+            console.print(f"  [cyan]{step['action']:<22}[/cyan] {step['resource']}")
+
+        if dry_run:
+            console.print("\n[yellow]Dry run - no resources were created.[/yellow]")
+            return
+
+        console.print(f"\n[green]✅ CUR setup complete: {report_name}[/green]")
+        console.print(f"[dim]📍 Delivery Location: s3://{bucket}/{prefix}[/dim]")
+        console.print("[dim]⏳ First report delivery may take up to 24 hours[/dim]")
+
+    except Exception as e:
+        console.print(f"[red]Error setting up CUR:[/red] {e}")
         raise click.Abort()
 
 

--- a/docs/commands/billing.md
+++ b/docs/commands/billing.md
@@ -86,6 +86,72 @@ aws-cloud-utilities billing cur-create \
   --schema-elements RESOURCES
 ```
 
+### cur-setup
+
+Provision an **end-to-end** CUR data source in one command: the delivery S3
+bucket (public-access block, AES256 encryption, lifecycle policy, and the
+billing-service bucket policy) plus a Parquet CUR report definition with
+resource IDs. This mirrors the reference Terraform module and is the
+recommended way to stand up CUR from scratch.
+
+Unlike `cur-create` (which assumes the bucket already exists and only patches
+its policy), `cur-setup` creates and fully configures the bucket for you.
+
+```bash
+aws-cloud-utilities billing cur-setup [OPTIONS]
+```
+
+**Required Options:**
+- `--bucket`: S3 bucket name for CUR delivery
+
+**Optional Options:**
+- `--report-name`: Name for the CUR report (default: `hourly-cur`)
+- `--prefix`: S3 prefix for CUR files (default: `cur`)
+- `--time-unit`: Time granularity, `HOURLY` or `DAILY` (default: `HOURLY`)
+- `--retention-days`: Days before CUR objects are expired by the lifecycle policy (default: `365`)
+- `--region`: Region for the S3 bucket (default: the session region)
+- `--enable-versioning`: Enable S3 bucket versioning (default: off)
+- `--dry-run`: Print the plan without creating anything
+
+**What it provisions (mirrors the reference Terraform):**
+- S3 bucket in the target region (us-east-1 handled without a `LocationConstraint`)
+- Public access block (all four settings enabled)
+- Default encryption (AES256)
+- Lifecycle policy: expire objects under `<prefix>/` after `--retention-days`,
+  expire noncurrent versions after 30 days, and abort incomplete multipart
+  uploads after 7 days
+- Bucket policy granting `billingreports.amazonaws.com` `GetBucketAcl`,
+  `GetBucketPolicy`, and `PutObject`, scoped by `aws:SourceArn` and
+  `aws:SourceAccount`
+- CUR report definition: Parquet format + Parquet compression, `RESOURCES`
+  schema element, `RefreshClosedReports`, and `OVERWRITE_REPORT` versioning
+
+The command is idempotent-friendly: an existing bucket is detected and left in
+place (its configuration is still re-applied), and an existing report
+definition is reported and skipped rather than failing.
+
+**Examples:**
+```bash
+# Preview the full plan without touching AWS
+aws-cloud-utilities billing cur-setup --bucket my-cur-bucket --dry-run
+
+# Provision an hourly CUR with defaults
+aws-cloud-utilities billing cur-setup --bucket my-cur-bucket
+
+# Daily CUR in us-west-2 with a 730-day retention and versioning
+aws-cloud-utilities billing cur-setup \
+  --bucket my-cur-bucket \
+  --report-name daily-cur \
+  --prefix cur \
+  --time-unit DAILY \
+  --retention-days 730 \
+  --region us-west-2 \
+  --enable-versioning
+```
+
+> **Note:** The CUR API is only available in `us-east-1`, so the report
+> definition is always created there regardless of the bucket's region.
+
 ### cur-delete
 
 Delete a Cost and Usage Report.
@@ -181,6 +247,12 @@ The `cur-create` command will automatically configure the required bucket policy
   - `s3:GetBucketPolicy`
   - `s3:PutBucketPolicy`
   - `s3:PutObject` (for the target S3 bucket)
+- Additional permissions used by `cur-setup` when provisioning the bucket:
+  - `s3:CreateBucket`
+  - `s3:PutBucketPublicAccessBlock`
+  - `s3:PutEncryptionConfiguration`
+  - `s3:PutLifecycleConfiguration`
+  - `s3:PutBucketVersioning` (only with `--enable-versioning`)
 
 ## Notes
 

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -1,0 +1,402 @@
+"""Tests for the billing CUR setup command and CURManager provisioning."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+from click.testing import CliRunner
+
+from aws_cloud_utilities.cli import main
+from aws_cloud_utilities.commands.billing import CURManager
+from aws_cloud_utilities.core.exceptions import AWSError
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_manager(region="us-east-1"):
+    """Build a CURManager with fully mocked AWS clients.
+
+    Patches ``__init__`` so no real STS/CUR/S3 calls happen; wires up mock
+    ``cur_client``/``s3_client`` and a mock ``aws_auth`` whose ``get_client``
+    returns a region-scoped S3 client.
+    """
+    manager = CURManager.__new__(CURManager)
+    manager.logger = MagicMock()
+    manager.account_id = "123456789012"
+    manager.cur_client = MagicMock()
+    manager.s3_client = MagicMock()
+
+    region_s3 = MagicMock()
+    aws_auth = MagicMock()
+    aws_auth.region_name = region
+    aws_auth.get_client.return_value = region_s3
+    manager.aws_auth = aws_auth
+    return manager
+
+
+def _not_found_error():
+    return ClientError({"Error": {"Code": "404", "Message": "Not Found"}}, "HeadBucket")
+
+
+# ---------------------------------------------------------------------------
+# bucket_exists / report_exists
+# ---------------------------------------------------------------------------
+
+
+class TestBucketExists:
+    def test_returns_true_when_head_succeeds(self):
+        mgr = _make_manager()
+        client = MagicMock()
+        assert mgr.bucket_exists("b", client) is True
+        client.head_bucket.assert_called_once_with(Bucket="b")
+
+    def test_returns_false_when_not_found(self):
+        mgr = _make_manager()
+        client = MagicMock()
+        client.head_bucket.side_effect = _not_found_error()
+        assert mgr.bucket_exists("b", client) is False
+
+    def test_raises_when_owned_by_another_account(self):
+        mgr = _make_manager()
+        client = MagicMock()
+        client.head_bucket.side_effect = ClientError(
+            {"Error": {"Code": "403", "Message": "Forbidden"}}, "HeadBucket"
+        )
+        with pytest.raises(AWSError, match="not owned by this account"):
+            mgr.bucket_exists("b", client)
+
+
+class TestReportExists:
+    def test_true_when_details_found(self):
+        mgr = _make_manager()
+        mgr.get_cur_details = MagicMock(return_value={"ReportName": "r"})
+        assert mgr.report_exists("r") is True
+
+    def test_false_when_details_none(self):
+        mgr = _make_manager()
+        mgr.get_cur_details = MagicMock(return_value=None)
+        assert mgr.report_exists("r") is False
+
+
+# ---------------------------------------------------------------------------
+# create_cur_bucket - region handling
+# ---------------------------------------------------------------------------
+
+
+class TestCreateCurBucket:
+    def test_us_east_1_omits_location_constraint(self):
+        mgr = _make_manager()
+        client = MagicMock()
+        mgr.create_cur_bucket("b", "us-east-1", client)
+        client.create_bucket.assert_called_once_with(Bucket="b")
+
+    def test_other_region_sets_location_constraint(self):
+        mgr = _make_manager()
+        client = MagicMock()
+        mgr.create_cur_bucket("b", "us-west-2", client)
+        client.create_bucket.assert_called_once_with(
+            Bucket="b",
+            CreateBucketConfiguration={"LocationConstraint": "us-west-2"},
+        )
+
+    def test_already_owned_is_swallowed(self):
+        mgr = _make_manager()
+        client = MagicMock()
+        client.create_bucket.side_effect = ClientError(
+            {"Error": {"Code": "BucketAlreadyOwnedByYou", "Message": "x"}},
+            "CreateBucket",
+        )
+        # Should not raise
+        mgr.create_cur_bucket("b", "us-east-1", client)
+
+
+# ---------------------------------------------------------------------------
+# apply_bucket_security / apply_lifecycle_policy
+# ---------------------------------------------------------------------------
+
+
+class TestApplyBucketSecurity:
+    def test_blocks_all_public_access_and_encrypts(self):
+        mgr = _make_manager()
+        client = MagicMock()
+        mgr.apply_bucket_security("b", enable_versioning=False, s3_client=client)
+
+        pab = client.put_public_access_block.call_args.kwargs[
+            "PublicAccessBlockConfiguration"
+        ]
+        assert pab == {
+            "BlockPublicAcls": True,
+            "IgnorePublicAcls": True,
+            "BlockPublicPolicy": True,
+            "RestrictPublicBuckets": True,
+        }
+        enc = client.put_bucket_encryption.call_args.kwargs[
+            "ServerSideEncryptionConfiguration"
+        ]
+        assert (
+            enc["Rules"][0]["ApplyServerSideEncryptionByDefault"]["SSEAlgorithm"]
+            == "AES256"
+        )
+        client.put_bucket_versioning.assert_not_called()
+
+    def test_versioning_enabled_when_requested(self):
+        mgr = _make_manager()
+        client = MagicMock()
+        mgr.apply_bucket_security("b", enable_versioning=True, s3_client=client)
+        client.put_bucket_versioning.assert_called_once_with(
+            Bucket="b", VersioningConfiguration={"Status": "Enabled"}
+        )
+
+
+class TestApplyLifecyclePolicy:
+    def test_lifecycle_rules_match_reference(self):
+        mgr = _make_manager()
+        client = MagicMock()
+        mgr.apply_lifecycle_policy("b", "cur", 365, client)
+
+        cfg = client.put_bucket_lifecycle_configuration.call_args.kwargs[
+            "LifecycleConfiguration"
+        ]
+        rules = {r["ID"]: r for r in cfg["Rules"]}
+
+        expire = rules["delete-old-cur-data"]
+        assert expire["Filter"] == {"Prefix": "cur/"}
+        assert expire["Expiration"] == {"Days": 365}
+        assert expire["NoncurrentVersionExpiration"] == {"NoncurrentDays": 30}
+
+        multipart = rules["abort-incomplete-multipart-uploads"]
+        assert multipart["AbortIncompleteMultipartUpload"] == {"DaysAfterInitiation": 7}
+
+
+# ---------------------------------------------------------------------------
+# create_report_definition - mirrors reference Terraform
+# ---------------------------------------------------------------------------
+
+
+class TestCreateReportDefinition:
+    def test_report_definition_params(self):
+        mgr = _make_manager()
+        mgr.create_report_definition("r", "b", "cur", "HOURLY", "us-east-1")
+
+        rd = mgr.cur_client.put_report_definition.call_args.kwargs["ReportDefinition"]
+        assert rd["Format"] == "Parquet"
+        assert rd["Compression"] == "Parquet"
+        assert rd["AdditionalSchemaElements"] == ["RESOURCES"]
+        assert rd["RefreshClosedReports"] is True
+        assert rd["ReportVersioning"] == "OVERWRITE_REPORT"
+        assert rd["TimeUnit"] == "HOURLY"
+        assert rd["S3Region"] == "us-east-1"
+        # setup uses a lean definition (no Redshift/QuickSight artifacts)
+        assert "AdditionalArtifacts" not in rd
+
+    def test_daily_time_unit_passthrough(self):
+        mgr = _make_manager()
+        mgr.create_report_definition("r", "b", "cur", "DAILY", "us-west-2")
+        rd = mgr.cur_client.put_report_definition.call_args.kwargs["ReportDefinition"]
+        assert rd["TimeUnit"] == "DAILY"
+
+    def test_duplicate_report_raises(self):
+        mgr = _make_manager()
+        mgr.cur_client.put_report_definition.side_effect = Exception(
+            "DuplicateReportNameException: exists"
+        )
+        with pytest.raises(AWSError, match="already exists"):
+            mgr.create_report_definition("r", "b", "cur", "HOURLY", "us-east-1")
+
+
+# ---------------------------------------------------------------------------
+# _create_bucket_policy - principal + SourceArn condition
+# ---------------------------------------------------------------------------
+
+
+class TestBucketPolicy:
+    def test_policy_grants_billing_service_with_source_conditions(self):
+        mgr = _make_manager()
+        client = MagicMock()
+        mgr._create_bucket_policy("b", "cur", client)
+
+        policy = json.loads(client.put_bucket_policy.call_args.kwargs["Policy"])
+        statements = policy["Statement"]
+        # Both statements target the billing service principal.
+        for stmt in statements:
+            assert stmt["Principal"] == {"Service": "billingreports.amazonaws.com"}
+            cond = stmt["Condition"]["StringEquals"]
+            assert (
+                cond["aws:SourceArn"]
+                == "arn:aws:cur:us-east-1:123456789012:definition/*"
+            )
+            assert cond["aws:SourceAccount"] == "123456789012"
+
+        # One statement allows PutObject on the prefixed objects.
+        put_stmt = [s for s in statements if s["Action"] == "s3:PutObject"][0]
+        assert put_stmt["Resource"] == "arn:aws:s3:::b/cur/*"
+
+
+# ---------------------------------------------------------------------------
+# setup_cur - orchestration, idempotency, dry-run
+# ---------------------------------------------------------------------------
+
+
+class TestSetupCur:
+    def test_dry_run_makes_no_mutating_calls(self):
+        mgr = _make_manager()
+        mgr.bucket_exists = MagicMock(return_value=False)
+        mgr.report_exists = MagicMock(return_value=False)
+        mgr.create_cur_bucket = MagicMock()
+        mgr.apply_bucket_security = MagicMock()
+        mgr.apply_lifecycle_policy = MagicMock()
+        mgr._create_bucket_policy = MagicMock()
+        mgr.create_report_definition = MagicMock()
+
+        summary = mgr.setup_cur(
+            report_name="r",
+            bucket="b",
+            prefix="cur",
+            time_unit="HOURLY",
+            retention_days=365,
+            dry_run=True,
+        )
+
+        assert summary["dry_run"] is True
+        assert summary["region"] == "us-east-1"
+        assert any("create" == s["action"] for s in summary["steps"])
+        mgr.create_cur_bucket.assert_not_called()
+        mgr.apply_bucket_security.assert_not_called()
+        mgr.apply_lifecycle_policy.assert_not_called()
+        mgr._create_bucket_policy.assert_not_called()
+        mgr.create_report_definition.assert_not_called()
+
+    def test_full_provision_creates_everything(self):
+        mgr = _make_manager()
+        mgr.bucket_exists = MagicMock(return_value=False)
+        mgr.report_exists = MagicMock(return_value=False)
+        mgr.create_cur_bucket = MagicMock()
+        mgr.apply_bucket_security = MagicMock()
+        mgr.apply_lifecycle_policy = MagicMock()
+        mgr._create_bucket_policy = MagicMock()
+        mgr.create_report_definition = MagicMock()
+
+        mgr.setup_cur(
+            report_name="r",
+            bucket="b",
+            prefix="cur",
+            time_unit="HOURLY",
+            retention_days=365,
+        )
+
+        mgr.create_cur_bucket.assert_called_once()
+        mgr.apply_bucket_security.assert_called_once()
+        mgr.apply_lifecycle_policy.assert_called_once()
+        mgr._create_bucket_policy.assert_called_once()
+        mgr.create_report_definition.assert_called_once()
+
+    def test_existing_bucket_is_not_recreated_but_config_reapplied(self):
+        mgr = _make_manager()
+        mgr.bucket_exists = MagicMock(return_value=True)
+        mgr.report_exists = MagicMock(return_value=False)
+        mgr.create_cur_bucket = MagicMock()
+        mgr.apply_bucket_security = MagicMock()
+        mgr.apply_lifecycle_policy = MagicMock()
+        mgr._create_bucket_policy = MagicMock()
+        mgr.create_report_definition = MagicMock()
+
+        summary = mgr.setup_cur(
+            report_name="r",
+            bucket="b",
+            prefix="cur",
+            time_unit="HOURLY",
+            retention_days=365,
+        )
+
+        mgr.create_cur_bucket.assert_not_called()
+        mgr.apply_bucket_security.assert_called_once()
+        mgr.create_report_definition.assert_called_once()
+        assert summary["steps"][0]["action"] == "already exists"
+
+    def test_existing_report_is_skipped(self):
+        mgr = _make_manager()
+        mgr.bucket_exists = MagicMock(return_value=True)
+        mgr.report_exists = MagicMock(return_value=True)
+        mgr.apply_bucket_security = MagicMock()
+        mgr.apply_lifecycle_policy = MagicMock()
+        mgr._create_bucket_policy = MagicMock()
+        mgr.create_report_definition = MagicMock()
+
+        summary = mgr.setup_cur(
+            report_name="r",
+            bucket="b",
+            prefix="cur",
+            time_unit="HOURLY",
+            retention_days=365,
+        )
+
+        mgr.create_report_definition.assert_not_called()
+        assert "skipped" in summary["steps"][-1]["action"]
+
+    def test_region_resolution_prefers_explicit_arg(self):
+        mgr = _make_manager(region="eu-west-1")
+        mgr.bucket_exists = MagicMock(return_value=True)
+        mgr.report_exists = MagicMock(return_value=True)
+        mgr.apply_bucket_security = MagicMock()
+        mgr.apply_lifecycle_policy = MagicMock()
+        mgr._create_bucket_policy = MagicMock()
+
+        summary = mgr.setup_cur(
+            report_name="r",
+            bucket="b",
+            prefix="cur",
+            time_unit="HOURLY",
+            retention_days=365,
+            region="ap-south-1",
+        )
+
+        assert summary["region"] == "ap-south-1"
+        mgr.aws_auth.get_client.assert_called_once_with("s3", region_name="ap-south-1")
+
+
+# ---------------------------------------------------------------------------
+# CLI wiring
+# ---------------------------------------------------------------------------
+
+
+class TestCurSetupCommand:
+    def test_help_lists_options(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["billing", "cur-setup", "--help"])
+        assert result.exit_code == 0
+        assert "--bucket" in result.output
+        assert "--dry-run" in result.output
+        assert "--time-unit" in result.output
+
+    def test_bucket_is_required(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["billing", "cur-setup"])
+        assert result.exit_code != 0
+        assert "bucket" in result.output.lower()
+
+    @patch("aws_cloud_utilities.commands.billing.CURManager")
+    def test_dry_run_invokes_setup_and_prints_plan(self, mock_manager_cls):
+        mock_manager = MagicMock()
+        mock_manager.setup_cur.return_value = {
+            "region": "us-east-1",
+            "dry_run": True,
+            "steps": [{"resource": "S3 bucket s3://b", "action": "create"}],
+        }
+        mock_manager_cls.return_value = mock_manager
+
+        runner = CliRunner()
+        with (
+            patch("aws_cloud_utilities.cli.AWSAuth"),
+            patch("aws_cloud_utilities.cli.Config"),
+        ):
+            result = runner.invoke(
+                main,
+                ["billing", "cur-setup", "--bucket", "b", "--dry-run"],
+            )
+
+        assert result.exit_code == 0
+        assert mock_manager.setup_cur.call_args.kwargs["dry_run"] is True
+        assert "no resources were created" in result.output.lower()


### PR DESCRIPTION
## Summary

Adds a new `billing cur-setup` command that provisions a **complete** AWS Cost and Usage Report (CUR) data source in a single step — the delivery S3 bucket *and* the report definition. This mirrors the reference Terraform module used elsewhere in our FinOps tooling and is step one of a FinOps flow (provisioning the data source).

CUR functionality already lived in `aws_cloud_utilities/commands/billing.py` (the `billing` command group, with `cur-create`, `cur-list`, `cur-details`, `cur-delete`, `cur-validate-bucket`). Rather than duplicate, this **extends `CURManager`**. The existing `cur-create` only patches a policy on a pre-existing bucket and defaults to CSV/GZIP; `cur-setup` instead creates and fully configures the bucket and registers a Parquet report — matching the Terraform.

## What `cur-setup` provisions (mirrors the reference Terraform)

- **S3 bucket** in the target region (us-east-1 handled without a `LocationConstraint`; other regions get one)
- **Public access block** — all four settings enabled
- **Default encryption** — AES256
- **Lifecycle policy** — expire objects under `<prefix>/` after `--retention-days`, expire noncurrent versions after 30 days, abort incomplete multipart uploads after 7 days
- **Bucket policy** — grants `billingreports.amazonaws.com` `GetBucketAcl`/`GetBucketPolicy`/`PutObject`, scoped by `aws:SourceArn = arn:aws:cur:us-east-1:<account>:definition/*` and `aws:SourceAccount`
- **CUR report definition** — Parquet format + Parquet compression, `RESOURCES` schema element, `RefreshClosedReports=true`, `ReportVersioning=OVERWRITE_REPORT`, configurable `HOURLY`/`DAILY` time unit

Critical AWS detail handled explicitly: the CUR API (`boto3.client("cur")`) exists **only in us-east-1**, so the report definition is always created there regardless of the bucket's region.

### Options
`--bucket` (required), `--report-name` (default `hourly-cur`), `--prefix` (default `cur`), `--time-unit` (HOURLY|DAILY, default HOURLY), `--retention-days` (default 365), `--region` (default session region), `--enable-versioning`, `--dry-run`. No account-specific values are hardcoded — all generic defaults.

Idempotent-friendly: detects an existing bucket (left in place, config re-applied) and an existing report definition (reported and skipped) instead of crashing.

## Files changed
- `aws_cloud_utilities/commands/billing.py` — new `CURManager` methods (`bucket_exists`, `report_exists`, `create_cur_bucket`, `apply_bucket_security`, `apply_lifecycle_policy`, `create_report_definition`, `_build_setup_plan`, `setup_cur`) + the `cur-setup` click command. `_create_bucket_policy` gained an optional region-scoped `s3_client` param (existing callers unaffected).
- `tests/test_billing.py` — new, 23 unit tests (boto3 fully mocked, no real AWS)
- `docs/commands/billing.md` — `cur-setup` section + IAM prerequisites
- `CHANGELOG.md` — Unreleased entry

## Testing done
- Full suite green locally: **58 passed** (35 pre-existing + 23 new)
- Tests cover: bucket creation (us-east-1 vs other-region `LocationConstraint`), bucket policy content (correct principal + `SourceArn`/`SourceAccount` conditions + `PutObject` resource), report-definition params (Parquet / RESOURCES / refresh / OVERWRITE / time-unit passthrough), us-east-1 pinning of the cur client, `--dry-run` makes no mutating calls, and the "already exists" idempotency paths for both bucket and report
- `flake8` clean, `black --check` clean, `isort` clean
- `aws-cloud-utilities billing --help` and `billing cur-setup --help` both render the new subcommand and options
- Did **not** run against real AWS; no AWS resources were created

## Notes
- mypy reports 4 errors on this file, but all 4 pre-exist on `main` (in `get_cur_details`, `create_cur_report`, and the `billing_group` decorator). The new code adds zero mypy errors.
- GitHub Actions is disabled account-wide on this org due to a billing issue, so CI will fail in ~1-2s with a billing annotation — expected, not related to this change. Local tests are the gate.